### PR TITLE
Ft fix living wage bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-
+source 'https://rubygems.org'
 gem "jekyll", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
@@ -59,4 +60,4 @@ DEPENDENCIES
   jekyll (~> 3.8)
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
                   Domestic workers are often consulted for important decisions within the family with 60% of them providing financial assistance for their households.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong><a href="http://www.kudheiha.org/domestic-workers/">Domestic Workers</a>
+                  <strong>Source:</strong> <a href="http://www.kudheiha.org/domestic-workers/">Domestic Workers</a>
                 </p>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -615,7 +615,7 @@
                   We limit the slider to KSH10000 because households are unlikely to be willing to pay more than that for kids. Public schools with fees and private schools can cost at KSH1000 and be upwards of KSH5000/month.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
+                  <strong>Source:</strong> <a href="https://openafrica.net/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                   </ul>
                 </p>
               </div>

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
                   We have not incorporated the food nutrition program or child support grants in our assessment. We feel our values are still quite conservative.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
+                  <strong>Source:</strong> <a href="https://openafrica.net/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                 </p>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
           <div class="row">
             <div class="col-sm-12">
               <p class="lead">
-                At this rate, you are paying the equivalent of <strong><span id="output-amount">R0</span></strong> per month.
+                At this rate, you are paying the equivalent of <strong><span id="output-amount">KSH0</span></strong> per month.
               </p>
             </div>
           </div>
@@ -262,8 +262,8 @@
                           data-slider-min="1"
                           data-slider-max="20"
                           data-slider-step="1"
-                          value="3"
-                          data-slider-value="3"
+                          value="1"
+                          data-slider-value="1"
                           data-slider-formater="people"/><br>
                     </div>
   
@@ -280,7 +280,7 @@
                   75% of domestic workers are known to be sole income providers for their households.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong> NIDS 2012
+                  <strong>Source:</strong><a href="http://www.kudheiha.org/domestic-workers/">Domestic Workers</a>
                 </p>
               </div>
             </div>
@@ -296,7 +296,7 @@
             <div class="panel-heading" data-toggle="collapse" data-target="#panel-food-expenses">
               <h4 class="panel-title">
                 <span>
-                  2. Food Cost <span id="food-total" class="pull-right">R...</span>
+                  2. Food Cost <span id="food-total" class="pull-right">KSH...</span>
                 </span>
               </h4>
             </div>
@@ -319,8 +319,8 @@
                                   data-slider-min="5"
                                   data-slider-max="5000"
                                   data-slider-step="1"
-                                  value="345"
-                                  data-slider-value="345"
+                                  value="170"
+                                  data-slider-value="170"
                                   data-slider-formater="KSH"/><br>
   
                               <!--<button type="button" class="btn btn-danger" value="15">R15, Carb Heavy Diet</button>-->
@@ -344,7 +344,7 @@
                   We have not incorporated the food nutrition program or child support grants in our assessment. We feel our values are still quite conservative.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong> KNBS - CPI Jan 2019
+                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                 </p>
               </div>
             </div>
@@ -381,9 +381,9 @@
                                   name="transport-cost"
                                   data-slider-min="30"
                                   data-slider-max="200"
-                                  data-slider-step="1"
-                                  value="46"
-                                  data-slider-value="46"
+                                  data-slider-step="5"
+                                  value="50"
+                                  data-slider-value="50"
                                   data-slider-formater="KSH"/><br>
                             </div>
                             <div class="form-group">
@@ -403,7 +403,7 @@
   
                               </div>
   
-                <p class="note">Travel costs are known to be high for domestic workers. <strong>We assume a need of KSH46 one way to get to work</strong>, based on the Consumer Price Indices and Inflation Rates for January 2019
+                <p class="note">Travel costs are known to be high for domestic workers. <strong>We assume a need of KSH50 one way to get to work</strong>, based on the Consumer Price Indices and Inflation Rates for January 2019
                 </p>
                 <p class="note">
                   We assume the cost of getting from Kawangware to a Nairobi suburb as the base. It is true it can take up to two minibus taxi trips to leave home and arrive at work. These trips combined cost between KSH30-50. Daily this can then be KSH60-100.
@@ -471,7 +471,7 @@
                   Associations with violence and sanitation taken from this data as well. Where rent was not paid (or reported), the assumption was that the household lived in informal risky settings. We don't want to highlight that as a residential option.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong> Housing - NIDS 2012, UCT
+                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                 </p>
               </div>
             </div>
@@ -585,8 +585,8 @@
                                   data-slider-min="0"
                                   data-slider-max="7"
                                   data-slider-step="1"
-                                  value="3"
-                                  data-slider-value="3"
+                                  value="1"
+                                  data-slider-value="1"
                                   data-slider-formater="children"/><br>
                             </div>  
   
@@ -615,9 +615,7 @@
                   We limit the slider to KSH10000 because households are unlikely to be willing to pay more than that for kids. Public schools with fees and private schools can cost at KSH1000 and be upwards of KSH5000/month.
                 </p>
                 <p class="sources">
-                  <strong>Sources:</strong>
-                  <a href="https://www.knbs.or.ke/download/consumer-price-indices-and-inflation-rates-for-january-2019/">Consumer Price Indices and Inflation Rates for January 2019</a>
-                  <a href="https://www.prb.org/international/geography/kenya/">International Data</a>
+                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                   </ul>
                 </p>
               </div>
@@ -646,7 +644,7 @@
                                   <div class="col-sm-9">
   
                                           <div class="form-group">
-                              <label for="communication-cost" class="lead question">What do you estimate each member of your domestic worker's household spends on <strong>communcation</strong>?</label><br>
+                              <label for="communication-cost" class="lead question">What do you estimate each member of your domestic worker's household spends on <strong>communication</strong>?</label><br>
                               <p>Estimate the monthly cost per person in the household:</p>
                               <input
                                   id="communication-cost"

--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@
                   </div>
   
                 <p class="note">
-                  75% of domestic workers are known to be sole income providers for their households.
+                  Domestic workers are often consulted for important decisions within the family with 60% of them providing financial assistance for their households.
                 </p>
                 <p class="sources">
                   <strong>Source:</strong><a href="http://www.kudheiha.org/domestic-workers/">Domestic Workers</a>
@@ -782,7 +782,7 @@
                     These include clothing, household items, personal care, and emergency expenses. Estimate other costs incurred per person in the household.
                 </p>
                 <p class="note">
-                  This should including for emergencies and procurement of durable goods, transportation of goods (gas cylinders, groceries, etc), implicit and explicit costs of running a household.
+                  This should include for emergencies and procurement of durable goods, transportation of goods (gas cylinders, groceries, etc), implicit and explicit costs of running a household.
                 </p>
   
             </div>

--- a/index.html
+++ b/index.html
@@ -471,7 +471,7 @@
                   Associations with violence and sanitation taken from this data as well. Where rent was not paid (or reported), the assumption was that the household lived in informal risky settings. We don't want to highlight that as a residential option.
                 </p>
                 <p class="sources">
-                  <strong>Source:</strong><a href="https://africaopendata.org/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
+                  <strong>Source:</strong> <a href="https://openafrica.net/dataset/cpi_kenya_2018">CPI January 2019, KNBS</a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
##### What does this PR do
 - Update transportation cost
 - Update housing cost
 - Fixes spelling error
 - Finds Kenyan equivalent of NIDS domestic workers as key bread winners
 - Fixes food cost calculation
 - Updates number of children
 - Points all CPI sources to open africa datasets

##### Description of Task to be completed?
- Update "Transportation Cost" Assumption
- Update "Housing Cost" source
-  Spelling error in Communications Costs assumption
- Are 75% of domestic workers known to be sole income providers in *Kenya*?
- Fix food cost calculation default number
- Update no. of children under "Education"
- Point all CPI sources to openAFRICA Datasets

##### What are the relevant Pivotal Tracker stories?
- #165116875
- #165116859
- #165116828
- #165116780
- #165116753
- #165116741
- #164823395

##### Questions?
- A Kenyan equivalent for `75% of domestic workers known to be sole income providers` could not be found. Should this be scrapped off? We were only able to include this [http://www.kudheiha.org/domestic-workers/](url) from Kudheia. 
